### PR TITLE
msm8998-common: configs: wifi: enable QPower duty cycling

### DIFF
--- a/configs/wifi/WCNSS_qcom_cfg.ini
+++ b/configs/wifi/WCNSS_qcom_cfg.ini
@@ -224,7 +224,7 @@ gMaxMediumTime = 6000
 gRrmEnable=1
 
 #Enable Power Save offload
-gEnablePowerSaveOffload=3
+gEnablePowerSaveOffload=5
 
 #Enable firmware uart print
 gEnablefwprint=0


### PR DESCRIPTION
Legacy Power save enabled + Deep sleep Enabled seems to cause
Wi-Fi instability, making it turn off even when it's needed.
The stock value, Legacy Power save enabled + Deep sleep Disabled,
also works fine, but enabling Duty cycling QPower seems to give
better power consumption.

Change-Id: Ie6028f58717a9487c43e9acd7d8528f4246e2b02