### PR TITLE
msm8998-common: add camera watermark

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -43,6 +43,7 @@ vendor/lib64/hw/android.hardware.bluetooth@1.0-impl-qti.so
 vendor/lib64/libbtnv.so
 
 # Camera
+etc/dualcamera.png
 lib/libMiCameraHal.so
 lib/libskia.so:lib/libmisk.so
 lib/libtrueportrait.so


### PR DESCRIPTION
This is needed for the 8.4.19 libMiCameraHal.so to function.

Change-Id: I24b5e3c7179097196d116caa51f1376a569b99ee